### PR TITLE
use base64 data instead of blob

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,9 +28,11 @@ void main() {
   // iosLicenseKey: "YOUR_FLUTTER_IOS_LICENSE_KEY_GOES_HERE",
   // webLicenseKey: "YOUR_FLUTTER_WEB_LICENSE_KEY_GOES_HERE");
   //
-  Pspdfkit.initialize();
-  Pspdfkit.enableAnalytics(true);
 
+  Pspdfkit.initialize();
+  if (!kIsWeb) {
+    Pspdfkit.enableAnalytics(true);
+  }
   Pspdfkit.analyticsEventsListener = (eventName, attributes) {
     if (kDebugMode) {
       print('Analytics event: $eventName with attributes: $attributes');

--- a/example/lib/pspdfkit_basic_example.dart
+++ b/example/lib/pspdfkit_basic_example.dart
@@ -99,10 +99,16 @@ class _PspdfkitSplitExampleState extends State<PspdfkitSplitExample> {
     final pageOneBytes = await instance.exportPdfWithOperations(
       const PspdfkitWebKeepPagesOperation(pageIndexes: {1,},),
     );
-    final pdfBlob = html.Blob(pageOneBytes, 'application/pdf',);
+
+    // Convert bytes to base64 string
+    final base64String = html.window.btoa(String.fromCharCodes(pageOneBytes));
+
+    // Create a data URL with base64 content
+    final documentData = 'data:application/pdf;base64,$base64String';
+
     setState(
       () {
-        splitBlobPath = html.Url.createObjectUrlFromBlob(pdfBlob,);
+        splitBlobPath = documentData;
       },
     );
   }


### PR DESCRIPTION
This pull request includes changes to fix the PDF splitting custom implementation. The fix that work was converting PDF bytes to a base64 string instead of a blob. Please let us know it works for you.
